### PR TITLE
feat(config): centralize configuration into typed Config struct

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,5 @@ bin/
 *.test
 *.out
 vendor/
-agentos
-emailtest
+/agentos
+/emailtest

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ lint:
 	go vet ./...
 
 run:
-	set -a && . ./.env && set +a && go run ./cmd/agentos/
+	go run ./cmd/agentos/
 
 test-api:
 	bash scripts/test_api.sh

--- a/README.md
+++ b/README.md
@@ -66,13 +66,54 @@ Copy `.env.example` to `.env` and fill in the values you need:
 cp .env.example .env
 ```
 
-| Variable | Description |
-|---|---|
-| `COSTGUARD_URL` | Costguard gateway base URL |
-| `COSTGUARD_API_KEY` | Costguard API key |
-| `PORT` | HTTP server port (default `8080`) |
-| `GMAIL_*` | Gmail credentials — see [docs/email-setup.md](docs/email-setup.md) |
-| `OUTLOOK_*` | Outlook credentials — see [docs/email-setup.md](docs/email-setup.md) |
+Configuration is loaded at startup from `.env` (if present) and then from actual environment variables, which always take precedence over the file.
+
+### Server
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `COSTGUARD_URL` | **Yes** | — | Costguard gateway base URL (e.g. `http://localhost:8080`) |
+| `COSTGUARD_API_KEY` | No | — | Bearer token for the Costguard gateway |
+| `PORT` | No | `9091` | TCP port the HTTP server listens on |
+| `LOG_LEVEL` | No | `info` | Minimum log level: `debug`, `info`, `warn`, `error` |
+| `SESSION_TTL` | No | `24h` | How long idle sessions are kept in memory (e.g. `30m`, `12h`) |
+
+### Builder Agent
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `BUILDER_SANDBOX_DIR` | No | `workspace` | Root directory for all file/shell operations by the Builder Agent |
+
+### Gmail
+
+| Variable | Required | Description |
+|---|---|---|
+| `GMAIL_CLIENT_ID` | For Gmail | OAuth2 client ID — see [docs/email-setup.md](docs/email-setup.md) |
+| `GMAIL_CLIENT_SECRET` | For Gmail | OAuth2 client secret |
+| `GMAIL_REFRESH_TOKEN` | For Gmail | Long-lived refresh token (obtained via `make gmailauth`) |
+
+### Google Calendar
+
+| Variable | Required | Description |
+|---|---|---|
+| `GOOGLE_CAL_CLIENT_ID` | For Google Cal | OAuth2 client ID |
+| `GOOGLE_CAL_CLIENT_SECRET` | For Google Cal | OAuth2 client secret |
+| `GOOGLE_CAL_REFRESH_TOKEN` | For Google Cal | Long-lived refresh token (obtained via `make googlecalauth`) |
+
+### Outlook (email)
+
+| Variable | Required | Description |
+|---|---|---|
+| `OUTLOOK_CLIENT_ID` | For Outlook email | Azure app client ID — see [docs/email-setup.md](docs/email-setup.md) |
+| `OUTLOOK_CLIENT_SECRET` | No | Client secret (not required for device code flow apps) |
+| `OUTLOOK_REFRESH_TOKEN` | For Outlook email | Long-lived refresh token (obtained via `make outlookauth`) |
+
+### Outlook Calendar
+
+| Variable | Required | Description |
+|---|---|---|
+| `OUTLOOK_CAL_CLIENT_ID` | For Outlook Cal | Azure app client ID |
+| `OUTLOOK_CAL_REFRESH_TOKEN` | For Outlook Cal | Long-lived refresh token (obtained via `make outlookcalauth`) |
 
 ## API
 

--- a/cmd/agentos/main.go
+++ b/cmd/agentos/main.go
@@ -6,31 +6,34 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/marcoantonios1/Agent-OS/internal/app"
 	"github.com/marcoantonios1/Agent-OS/internal/agents/builder"
 	"github.com/marcoantonios1/Agent-OS/internal/agents/comms"
 	"github.com/marcoantonios1/Agent-OS/internal/approval"
-	"github.com/marcoantonios1/Agent-OS/internal/observability"
-	"github.com/marcoantonios1/Agent-OS/internal/tools/code"
 	"github.com/marcoantonios1/Agent-OS/internal/channels/web"
 	"github.com/marcoantonios1/Agent-OS/internal/costguard"
 	"github.com/marcoantonios1/Agent-OS/internal/memory"
+	"github.com/marcoantonios1/Agent-OS/internal/observability"
 	"github.com/marcoantonios1/Agent-OS/internal/router"
+	"github.com/marcoantonios1/Agent-OS/internal/tools/calendar"
 	calendarGoogle "github.com/marcoantonios1/Agent-OS/internal/tools/calendar/google"
 	calendarOutlook "github.com/marcoantonios1/Agent-OS/internal/tools/calendar/outlook"
-	"github.com/marcoantonios1/Agent-OS/internal/tools/calendar"
+	"github.com/marcoantonios1/Agent-OS/internal/tools/code"
+	"github.com/marcoantonios1/Agent-OS/internal/tools/email"
 	emailGmail "github.com/marcoantonios1/Agent-OS/internal/tools/email/gmail"
 	emailOutlook "github.com/marcoantonios1/Agent-OS/internal/tools/email/outlook"
-	"github.com/marcoantonios1/Agent-OS/internal/tools/email"
 	"github.com/marcoantonios1/Agent-OS/internal/types"
 )
 
 func main() {
-	port := os.Getenv("PORT")
-	if port == "" {
-		port = "9091"
+	// Load and validate configuration from .env + environment variables.
+	cfg, err := app.Load(".env")
+	if err != nil {
+		slog.Error("startup failed", "error", err)
+		os.Exit(1)
 	}
 
-	observability.Setup(os.Getenv("LOG_LEVEL"))
+	observability.Setup(cfg.LogLevel)
 
 	ctx := context.Background()
 
@@ -39,62 +42,38 @@ func main() {
 
 	approvals := approval.NewMemoryStore()
 
-	llm := newLLMClient()
+	llm := costguard.New(cfg.CostguardURL, cfg.CostguardAPIKey)
 	classifier := router.NewLLMClassifier(llm)
 
 	agents := map[router.Intent]router.Agent{
-		router.IntentComms:    comms.New(llm, newEmailProvider(ctx), newCalendarProvider(ctx), approvals),
-		router.IntentBuilder:  builder.New(llm, store, newBuilderConfig()),
+		router.IntentComms:    comms.New(llm, newEmailProvider(ctx, cfg), newCalendarProvider(ctx, cfg), approvals),
+		router.IntentBuilder:  builder.New(llm, store, newBuilderConfig(cfg)),
 		router.IntentResearch: &placeholderAgent{name: "research"},
 	}
 
 	r := router.New(classifier, agents, store, approvals)
 	h := web.NewHandler(r)
 
-	slog.Info("Agent OS starting", "port", port)
-	if err := http.ListenAndServe(":"+port, h); err != nil {
+	slog.Info("Agent OS starting", "port", cfg.Port)
+	if err := http.ListenAndServe(":"+cfg.Port, h); err != nil {
 		slog.Error("server error", "error", err)
 		os.Exit(1)
 	}
 }
 
-// newLLMClient returns a Costguard client when COSTGUARD_URL is set, or a
-// stub that returns a placeholder so the server starts without configuration.
-func newLLMClient() costguard.LLMClient {
-	if os.Getenv("COSTGUARD_URL") != "" {
-		return costguard.NewFromEnv()
-	}
-	slog.Warn("COSTGUARD_URL not set — using stub LLM client")
-	return &stubLLMClient{}
-}
-
-// stubLLMClient is used for local development when Costguard is not configured.
-// It classifies every message as "comms" so the server starts and responds.
-type stubLLMClient struct{}
-
-func (s *stubLLMClient) Complete(_ context.Context, _ costguard.CompletionRequest) (costguard.CompletionResponse, error) {
-	return costguard.CompletionResponse{Content: `{"intent":"comms"}`}, nil
-}
-
-func (s *stubLLMClient) Stream(_ context.Context, _ costguard.CompletionRequest) (<-chan costguard.StreamChunk, error) {
-	ch := make(chan costguard.StreamChunk)
-	close(ch)
-	return ch, nil
-}
-
-// newEmailProvider returns a Gmail or Outlook EmailProvider based on which env
-// vars are set, or nil if neither is configured.
-func newEmailProvider(ctx context.Context) email.EmailProvider {
-	if os.Getenv("GMAIL_CLIENT_ID") != "" {
-		p, err := emailGmail.NewFromEnv(ctx)
+// newEmailProvider returns a Gmail or Outlook EmailProvider based on which
+// credentials are present in cfg, or nil if neither is configured.
+func newEmailProvider(ctx context.Context, cfg *app.Config) email.EmailProvider {
+	if cfg.GmailConfigured() {
+		p, err := emailGmail.New(ctx, cfg.GmailClientID, cfg.GmailClientSecret, cfg.GmailRefreshToken)
 		if err != nil {
 			slog.Warn("Gmail provider unavailable", "error", err)
 			return nil
 		}
 		return p
 	}
-	if os.Getenv("OUTLOOK_CLIENT_ID") != "" {
-		p, err := emailOutlook.NewFromEnv(ctx)
+	if cfg.OutlookEmailConfigured() {
+		p, err := emailOutlook.New(ctx, cfg.OutlookClientID, cfg.OutlookClientSecret, cfg.OutlookRefreshToken)
 		if err != nil {
 			slog.Warn("Outlook email provider unavailable", "error", err)
 			return nil
@@ -106,20 +85,20 @@ func newEmailProvider(ctx context.Context) email.EmailProvider {
 }
 
 // newCalendarProvider returns a Google or Outlook CalendarProvider based on
-// which env vars are set, or nil if neither is configured.
-func newCalendarProvider(ctx context.Context) calendar.CalendarProvider {
-	if os.Getenv("GOOGLE_CAL_CLIENT_ID") != "" {
-		p, err := calendarGoogle.NewFromEnv(ctx)
+// which credentials are present in cfg, or nil if neither is configured.
+func newCalendarProvider(ctx context.Context, cfg *app.Config) calendar.CalendarProvider {
+	if cfg.GoogleCalConfigured() {
+		p, err := calendarGoogle.New(ctx, cfg.GoogleCalClientID, cfg.GoogleCalClientSecret, cfg.GoogleCalRefreshToken)
 		if err != nil {
 			slog.Warn("Google Calendar provider unavailable", "error", err)
 			return nil
 		}
 		return p
 	}
-	if os.Getenv("OUTLOOK_CLIENT_ID") != "" {
-		p, err := calendarOutlook.NewFromEnv(ctx)
+	if cfg.OutlookCalConfigured() {
+		p, err := calendarOutlook.New(ctx, cfg.OutlookCalClientID, cfg.OutlookCalRefreshToken)
 		if err != nil {
-			slog.Warn("Outlook calendar provider unavailable", "error", err)
+			slog.Warn("Outlook Calendar provider unavailable", "error", err)
 			return nil
 		}
 		return p
@@ -129,15 +108,9 @@ func newCalendarProvider(ctx context.Context) calendar.CalendarProvider {
 }
 
 // newBuilderConfig returns a code.Config for the Builder Agent sandbox.
-// The sandbox directory defaults to a "workspace" folder next to the binary;
-// override with BUILDER_SANDBOX_DIR.
-func newBuilderConfig() code.Config {
-	dir := os.Getenv("BUILDER_SANDBOX_DIR")
-	if dir == "" {
-		dir = "workspace"
-	}
-	os.MkdirAll(dir, 0o755) //nolint:errcheck
-	return code.Config{SandboxDir: dir}
+func newBuilderConfig(cfg *app.Config) code.Config {
+	os.MkdirAll(cfg.BuilderSandboxDir, 0o755) //nolint:errcheck
+	return code.Config{SandboxDir: cfg.BuilderSandboxDir}
 }
 
 // placeholderAgent is used until real agent implementations are wired in.

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -1,0 +1,231 @@
+// Package app provides application-level bootstrapping for Agent OS:
+// configuration loading, validation, and provider wiring.
+//
+// # Usage
+//
+//	cfg, err := app.Load(".env")
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//
+// Load reads from an optional .env file first, then from real environment
+// variables (which always take precedence). It validates required fields and
+// returns a descriptive error if any are missing.
+//
+// No code below main should call os.Getenv directly. Always pass a *Config.
+package app
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+)
+
+// Config holds all runtime configuration for Agent OS. Every field maps 1-to-1
+// with an environment variable documented in README.md.
+type Config struct {
+	// ── Server ────────────────────────────────────────────────────────────────
+
+	// Port is the TCP port the HTTP server listens on.
+	// Env: PORT (default: "9091")
+	Port string
+
+	// LogLevel sets the minimum slog log level.
+	// Env: LOG_LEVEL (default: "info"). Valid: debug, info, warn, error.
+	LogLevel string
+
+	// ── Costguard LLM gateway ─────────────────────────────────────────────────
+
+	// CostguardURL is the base URL of the Costguard gateway. Required.
+	// Env: COSTGUARD_URL
+	CostguardURL string
+
+	// CostguardAPIKey is the optional bearer token for the Costguard gateway.
+	// Env: COSTGUARD_API_KEY
+	CostguardAPIKey string
+
+	// ── Gmail ─────────────────────────────────────────────────────────────────
+
+	// Env: GMAIL_CLIENT_ID, GMAIL_CLIENT_SECRET, GMAIL_REFRESH_TOKEN
+	GmailClientID     string
+	GmailClientSecret string
+	GmailRefreshToken string
+
+	// ── Google Calendar ───────────────────────────────────────────────────────
+
+	// Env: GOOGLE_CAL_CLIENT_ID, GOOGLE_CAL_CLIENT_SECRET, GOOGLE_CAL_REFRESH_TOKEN
+	GoogleCalClientID     string
+	GoogleCalClientSecret string
+	GoogleCalRefreshToken string
+
+	// ── Outlook email ─────────────────────────────────────────────────────────
+
+	// Env: OUTLOOK_CLIENT_ID, OUTLOOK_CLIENT_SECRET (optional), OUTLOOK_REFRESH_TOKEN
+	OutlookClientID     string
+	OutlookClientSecret string
+	OutlookRefreshToken string
+
+	// ── Outlook Calendar ──────────────────────────────────────────────────────
+
+	// Env: OUTLOOK_CAL_CLIENT_ID, OUTLOOK_CAL_REFRESH_TOKEN
+	OutlookCalClientID     string
+	OutlookCalRefreshToken string
+
+	// ── Builder Agent ─────────────────────────────────────────────────────────
+
+	// BuilderSandboxDir is the root directory for all file and shell operations
+	// performed by the Builder Agent.
+	// Env: BUILDER_SANDBOX_DIR (default: "workspace")
+	BuilderSandboxDir string
+
+	// ── Session store ─────────────────────────────────────────────────────────
+
+	// SessionTTL is how long idle sessions are kept in memory before expiry.
+	// Env: SESSION_TTL (default: 24h). Accepts any value parseable by time.ParseDuration.
+	SessionTTL time.Duration
+}
+
+// Load reads configuration from the given .env file (if it exists) and then
+// from actual environment variables, which take precedence over the file.
+// Returns a descriptive error if any required field is missing.
+func Load(envFile string) (*Config, error) {
+	if err := loadDotEnv(envFile); err != nil {
+		return nil, fmt.Errorf("config: load env file %q: %w", envFile, err)
+	}
+
+	cfg := &Config{
+		Port:     envOr("PORT", "9091"),
+		LogLevel: envOr("LOG_LEVEL", "info"),
+
+		CostguardURL:    os.Getenv("COSTGUARD_URL"),
+		CostguardAPIKey: os.Getenv("COSTGUARD_API_KEY"),
+
+		GmailClientID:     os.Getenv("GMAIL_CLIENT_ID"),
+		GmailClientSecret: os.Getenv("GMAIL_CLIENT_SECRET"),
+		GmailRefreshToken: os.Getenv("GMAIL_REFRESH_TOKEN"),
+
+		GoogleCalClientID:     os.Getenv("GOOGLE_CAL_CLIENT_ID"),
+		GoogleCalClientSecret: os.Getenv("GOOGLE_CAL_CLIENT_SECRET"),
+		GoogleCalRefreshToken: os.Getenv("GOOGLE_CAL_REFRESH_TOKEN"),
+
+		OutlookClientID:     os.Getenv("OUTLOOK_CLIENT_ID"),
+		OutlookClientSecret: os.Getenv("OUTLOOK_CLIENT_SECRET"),
+		OutlookRefreshToken: os.Getenv("OUTLOOK_REFRESH_TOKEN"),
+
+		OutlookCalClientID:     os.Getenv("OUTLOOK_CAL_CLIENT_ID"),
+		OutlookCalRefreshToken: os.Getenv("OUTLOOK_CAL_REFRESH_TOKEN"),
+
+		BuilderSandboxDir: envOr("BUILDER_SANDBOX_DIR", "workspace"),
+		SessionTTL:        envDuration("SESSION_TTL", 24*time.Hour),
+	}
+
+	if err := cfg.validate(); err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}
+
+// validate returns a descriptive error for any required field that is missing.
+func (c *Config) validate() error {
+	var missing []string
+	if c.CostguardURL == "" {
+		missing = append(missing, "COSTGUARD_URL is required — set it to your Costguard gateway base URL (e.g. http://localhost:8080)")
+	}
+	if len(missing) > 0 {
+		return errors.New("config: " + strings.Join(missing, "; "))
+	}
+	return nil
+}
+
+// GmailConfigured reports whether all three Gmail OAuth2 credentials are present.
+func (c *Config) GmailConfigured() bool {
+	return c.GmailClientID != "" && c.GmailClientSecret != "" && c.GmailRefreshToken != ""
+}
+
+// GoogleCalConfigured reports whether all Google Calendar credentials are present.
+func (c *Config) GoogleCalConfigured() bool {
+	return c.GoogleCalClientID != "" && c.GoogleCalClientSecret != "" && c.GoogleCalRefreshToken != ""
+}
+
+// OutlookEmailConfigured reports whether the minimum Outlook email credentials are present.
+func (c *Config) OutlookEmailConfigured() bool {
+	return c.OutlookClientID != "" && c.OutlookRefreshToken != ""
+}
+
+// OutlookCalConfigured reports whether Outlook Calendar credentials are present.
+func (c *Config) OutlookCalConfigured() bool {
+	return c.OutlookCalClientID != "" && c.OutlookCalRefreshToken != ""
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+func envOr(key, defaultVal string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return defaultVal
+}
+
+func envDuration(key string, defaultVal time.Duration) time.Duration {
+	v := os.Getenv(key)
+	if v == "" {
+		return defaultVal
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil {
+		return defaultVal
+	}
+	return d
+}
+
+// loadDotEnv reads KEY=VALUE pairs from the file at path and registers each as
+// an environment variable via os.Setenv. Lines that are already set in the
+// process environment are skipped so that real env vars always win.
+//
+// Supported syntax:
+//   - Blank lines and lines starting with # are ignored.
+//   - Values may be quoted with " or '; the quotes are stripped.
+//   - Inline comments are NOT supported (# after a value is part of the value).
+//
+// If the file does not exist, loadDotEnv returns nil without error.
+func loadDotEnv(path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil // .env is optional
+		}
+		return err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+
+		// Strip surrounding single or double quotes.
+		if len(value) >= 2 {
+			if (value[0] == '"' && value[len(value)-1] == '"') ||
+				(value[0] == '\'' && value[len(value)-1] == '\'') {
+				value = value[1 : len(value)-1]
+			}
+		}
+
+		// Real env vars win — only set if not already present.
+		if os.Getenv(key) == "" {
+			os.Setenv(key, value) //nolint:errcheck
+		}
+	}
+	return scanner.Err()
+}

--- a/internal/app/config_test.go
+++ b/internal/app/config_test.go
@@ -1,0 +1,221 @@
+package app_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/marcoantonios1/Agent-OS/internal/app"
+)
+
+// setEnv sets env vars for the duration of the test, restoring original values
+// (or unsetting) when the test completes.
+func setEnv(t *testing.T, pairs map[string]string) {
+	t.Helper()
+	for k, v := range pairs {
+		prev, existed := os.LookupEnv(k)
+		os.Setenv(k, v) //nolint:errcheck
+		t.Cleanup(func() {
+			if existed {
+				os.Setenv(k, prev) //nolint:errcheck
+			} else {
+				os.Unsetenv(k) //nolint:errcheck
+			}
+		})
+	}
+}
+
+// clearEnv ensures the given keys are unset for the duration of the test.
+func clearEnv(t *testing.T, keys ...string) {
+	t.Helper()
+	for _, k := range keys {
+		prev, existed := os.LookupEnv(k)
+		os.Unsetenv(k) //nolint:errcheck
+		t.Cleanup(func() {
+			if existed {
+				os.Setenv(k, prev) //nolint:errcheck
+			}
+		})
+	}
+}
+
+func writeDotEnv(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".env")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write temp .env: %v", err)
+	}
+	return path
+}
+
+func TestLoad_MissingCostguardURL_ReturnsError(t *testing.T) {
+	clearEnv(t, "COSTGUARD_URL")
+	_, err := app.Load("nonexistent.env")
+	if err == nil {
+		t.Fatal("expected error when COSTGUARD_URL is missing, got nil")
+	}
+	if want := "COSTGUARD_URL is required"; !containsStr(err.Error(), want) {
+		t.Errorf("error %q does not contain %q", err.Error(), want)
+	}
+}
+
+func TestLoad_ValidConfig_Succeeds(t *testing.T) {
+	setEnv(t, map[string]string{"COSTGUARD_URL": "http://localhost:8080"})
+	cfg, err := app.Load("nonexistent.env")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.CostguardURL != "http://localhost:8080" {
+		t.Errorf("CostguardURL = %q, want %q", cfg.CostguardURL, "http://localhost:8080")
+	}
+}
+
+func TestLoad_Defaults(t *testing.T) {
+	setEnv(t, map[string]string{"COSTGUARD_URL": "http://localhost:8080"})
+	clearEnv(t, "PORT", "LOG_LEVEL", "BUILDER_SANDBOX_DIR", "SESSION_TTL")
+
+	cfg, err := app.Load("nonexistent.env")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Port != "9091" {
+		t.Errorf("Port = %q, want %q", cfg.Port, "9091")
+	}
+	if cfg.LogLevel != "info" {
+		t.Errorf("LogLevel = %q, want %q", cfg.LogLevel, "info")
+	}
+	if cfg.BuilderSandboxDir != "workspace" {
+		t.Errorf("BuilderSandboxDir = %q, want %q", cfg.BuilderSandboxDir, "workspace")
+	}
+	if cfg.SessionTTL != 24*time.Hour {
+		t.Errorf("SessionTTL = %v, want %v", cfg.SessionTTL, 24*time.Hour)
+	}
+}
+
+func TestLoad_DotEnvFile_SetsValues(t *testing.T) {
+	clearEnv(t, "COSTGUARD_URL", "PORT", "LOG_LEVEL")
+
+	path := writeDotEnv(t, `
+# comment line
+COSTGUARD_URL=http://costguard:9000
+PORT=8888
+LOG_LEVEL=debug
+`)
+	cfg, err := app.Load(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.CostguardURL != "http://costguard:9000" {
+		t.Errorf("CostguardURL = %q, want %q", cfg.CostguardURL, "http://costguard:9000")
+	}
+	if cfg.Port != "8888" {
+		t.Errorf("Port = %q, want %q", cfg.Port, "8888")
+	}
+	if cfg.LogLevel != "debug" {
+		t.Errorf("LogLevel = %q, want %q", cfg.LogLevel, "debug")
+	}
+}
+
+func TestLoad_EnvVarOverridesDotEnv(t *testing.T) {
+	setEnv(t, map[string]string{"COSTGUARD_URL": "http://real:8080"})
+
+	path := writeDotEnv(t, "COSTGUARD_URL=http://from-file:9999\n")
+	cfg, err := app.Load(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Real env var must win.
+	if cfg.CostguardURL != "http://real:8080" {
+		t.Errorf("CostguardURL = %q, want %q (real env var should override .env)", cfg.CostguardURL, "http://real:8080")
+	}
+}
+
+func TestLoad_DotEnvFile_Quoted(t *testing.T) {
+	clearEnv(t, "COSTGUARD_URL", "COSTGUARD_API_KEY")
+
+	path := writeDotEnv(t, `COSTGUARD_URL="http://quoted:8080"
+COSTGUARD_API_KEY='my-key'
+`)
+	cfg, err := app.Load(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.CostguardURL != "http://quoted:8080" {
+		t.Errorf("CostguardURL = %q, want %q", cfg.CostguardURL, "http://quoted:8080")
+	}
+	if cfg.CostguardAPIKey != "my-key" {
+		t.Errorf("CostguardAPIKey = %q, want %q", cfg.CostguardAPIKey, "my-key")
+	}
+}
+
+func TestLoad_MissingDotEnvFile_NoError(t *testing.T) {
+	setEnv(t, map[string]string{"COSTGUARD_URL": "http://localhost:8080"})
+	_, err := app.Load("this-file-does-not-exist.env")
+	if err != nil {
+		t.Errorf("missing .env file should not be an error, got: %v", err)
+	}
+}
+
+func TestLoad_SessionTTL_Parsed(t *testing.T) {
+	setEnv(t, map[string]string{
+		"COSTGUARD_URL": "http://localhost:8080",
+		"SESSION_TTL":   "2h30m",
+	})
+	cfg, err := app.Load("nonexistent.env")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := 2*time.Hour + 30*time.Minute
+	if cfg.SessionTTL != want {
+		t.Errorf("SessionTTL = %v, want %v", cfg.SessionTTL, want)
+	}
+}
+
+func TestConfig_ProviderHelpers(t *testing.T) {
+	base := &app.Config{} // all empty
+
+	if base.GmailConfigured() {
+		t.Error("GmailConfigured() should be false when credentials are missing")
+	}
+	if base.GoogleCalConfigured() {
+		t.Error("GoogleCalConfigured() should be false when credentials are missing")
+	}
+	if base.OutlookEmailConfigured() {
+		t.Error("OutlookEmailConfigured() should be false when credentials are missing")
+	}
+	if base.OutlookCalConfigured() {
+		t.Error("OutlookCalConfigured() should be false when credentials are missing")
+	}
+
+	full := &app.Config{
+		GmailClientID:          "id",
+		GmailClientSecret:      "secret",
+		GmailRefreshToken:      "token",
+		GoogleCalClientID:      "id",
+		GoogleCalClientSecret:  "secret",
+		GoogleCalRefreshToken:  "token",
+		OutlookClientID:        "id",
+		OutlookRefreshToken:    "token",
+		OutlookCalClientID:     "id",
+		OutlookCalRefreshToken: "token",
+	}
+	if !full.GmailConfigured() {
+		t.Error("GmailConfigured() should be true when all credentials are set")
+	}
+	if !full.GoogleCalConfigured() {
+		t.Error("GoogleCalConfigured() should be true when all credentials are set")
+	}
+	if !full.OutlookEmailConfigured() {
+		t.Error("OutlookEmailConfigured() should be true when credentials are set")
+	}
+	if !full.OutlookCalConfigured() {
+		t.Error("OutlookCalConfigured() should be true when credentials are set")
+	}
+}
+
+func containsStr(s, substr string) bool {
+	return strings.Contains(s, substr)
+}


### PR DESCRIPTION
Adds internal/app package with a Config struct that covers every env var used by Agent OS. app.Load(".env") reads the optional .env file first, then real env vars (which always take precedence), and fails fast with a descriptive error when COSTGUARD_URL is missing.

- No code below main calls os.Getenv — all values are injected via *Config
- Provider constructors in main.go now receive explicit credentials from cfg
- Makefile run target simplified (app loads .env itself)
- .gitignore fixed: /agentos pattern was matching cmd/agentos/ source dir
- README documents all env vars with defaults and required flags