### PR TITLE
test: fix integration tests broken by classifier system-role change

### DIFF
--- a/test/integration/context_injection_test.go
+++ b/test/integration/context_injection_test.go
@@ -25,7 +25,7 @@ func TestContextInjection_CommsAgentAddressesUserByName(t *testing.T) {
 		},
 	})
 
-	var systemPrompt string
+	var capturedPrompts []string
 	capLLM := &capturingScriptedLLM{
 		responses: []costguard.CompletionResponse{
 			classifyResp("comms"),
@@ -33,8 +33,8 @@ func TestContextInjection_CommsAgentAddressesUserByName(t *testing.T) {
 		},
 		onCall: func(req costguard.CompletionRequest) {
 			for _, msg := range req.Messages {
-				if msg.Role == "system" && systemPrompt == "" {
-					systemPrompt = msg.Content
+				if msg.Role == "system" {
+					capturedPrompts = append(capturedPrompts, msg.Content)
 				}
 			}
 		},
@@ -59,19 +59,28 @@ func TestContextInjection_CommsAgentAddressesUserByName(t *testing.T) {
 		t.Error("expected non-empty response")
 	}
 
-	if systemPrompt == "" {
-		t.Fatal("no system prompt was captured")
+	// The classifier now uses a system role too, so multiple system prompts are
+	// captured. Find the comms agent one (it contains "Comms Agent").
+	var commsPrompt string
+	for _, p := range capturedPrompts {
+		if strings.Contains(p, "Comms Agent") {
+			commsPrompt = p
+			break
+		}
 	}
-	if !strings.Contains(systemPrompt, "Marco") {
-		t.Errorf("system prompt should contain the user's name 'Marco', got:\n%s", systemPrompt[:min(len(systemPrompt), 500)])
+	if commsPrompt == "" {
+		t.Fatalf("no comms system prompt captured; got %d system messages", len(capturedPrompts))
 	}
-	if !strings.Contains(systemPrompt, "concise") {
+	if !strings.Contains(commsPrompt, "Marco") {
+		t.Errorf("system prompt should contain the user's name 'Marco', got:\n%s", commsPrompt[:min(len(commsPrompt), 500)])
+	}
+	if !strings.Contains(commsPrompt, "concise") {
 		t.Errorf("system prompt should contain communication style 'concise'")
 	}
-	if !strings.Contains(systemPrompt, "alice@example.com") {
+	if !strings.Contains(commsPrompt, "alice@example.com") {
 		t.Errorf("system prompt should contain recurring contact email")
 	}
-	if !strings.Contains(systemPrompt, "sign_off") {
+	if !strings.Contains(commsPrompt, "sign_off") {
 		t.Errorf("system prompt should contain preferences")
 	}
 }

--- a/test/integration/phase2_test.go
+++ b/test/integration/phase2_test.go
@@ -228,7 +228,7 @@ func TestPhase2_Memory_ProfilePersistedAcrossSessions(t *testing.T) {
 	}
 
 	// Capture the system prompt sent to the agent in the NEW session.
-	var capturedSystemPrompt string
+	var capturedPrompts []string
 	capLLM := &capturingScriptedLLM{
 		responses: []costguard.CompletionResponse{
 			classifyResp("comms"),
@@ -236,8 +236,8 @@ func TestPhase2_Memory_ProfilePersistedAcrossSessions(t *testing.T) {
 		},
 		onCall: func(req costguard.CompletionRequest) {
 			for _, msg := range req.Messages {
-				if msg.Role == "system" && capturedSystemPrompt == "" {
-					capturedSystemPrompt = msg.Content
+				if msg.Role == "system" {
+					capturedPrompts = append(capturedPrompts, msg.Content)
 				}
 			}
 		},
@@ -267,21 +267,29 @@ func TestPhase2_Memory_ProfilePersistedAcrossSessions(t *testing.T) {
 		t.Error("expected non-empty response")
 	}
 
-	if capturedSystemPrompt == "" {
-		t.Fatal("no system prompt captured — check capturingScriptedLLM wiring")
+	// The classifier now uses system role too, so find the comms agent prompt.
+	var commsPrompt string
+	for _, p := range capturedPrompts {
+		if strings.Contains(p, "Comms Agent") {
+			commsPrompt = p
+			break
+		}
+	}
+	if commsPrompt == "" {
+		t.Fatalf("no comms system prompt captured; got %d system messages", len(capturedPrompts))
 	}
 
 	// The system prompt must contain the profile data from the previous session.
-	if !strings.Contains(capturedSystemPrompt, "Marco") {
-		t.Errorf("system prompt must contain user name 'Marco'; got:\n%.500s", capturedSystemPrompt)
+	if !strings.Contains(commsPrompt, "Marco") {
+		t.Errorf("system prompt must contain user name 'Marco'; got:\n%.500s", commsPrompt)
 	}
-	if !strings.Contains(capturedSystemPrompt, "formal") {
+	if !strings.Contains(commsPrompt, "formal") {
 		t.Errorf("system prompt must contain communication style 'formal'")
 	}
-	if !strings.Contains(capturedSystemPrompt, "UTC+3") {
+	if !strings.Contains(commsPrompt, "UTC+3") {
 		t.Errorf("system prompt must contain timezone preference 'UTC+3'")
 	}
-	if !strings.Contains(capturedSystemPrompt, "alice@example.com") {
+	if !strings.Contains(commsPrompt, "alice@example.com") {
 		t.Errorf("system prompt must contain recurring contact email")
 	}
 }


### PR DESCRIPTION
Two tests captured the first system-role message, which was previously the comms/builder agent prompt. After the classifier was updated to use role:"system" (instead of role:"user"), the classifier prompt was captured first, causing assertion failures.

Fix: collect all system prompts and filter to the agent-specific one by checking for "Comms Agent" in the content, matching the approach already used by TestContextInjection_BuilderSystemPromptIncludesProject.

No gaps found in research agent coverage — all four phase2 scenarios (structured findings, compound intent order, cross-session profile, project resume) are present and passing.