### PR TITLE
docs: define agent folder layout and agent.yaml config schema

### DIFF
--- a/docs/agent-config.md
+++ b/docs/agent-config.md
@@ -1,0 +1,232 @@
+# Agent configuration
+
+Every agent — built-in or user-defined — lives in its own subdirectory under
+`agents/`. The directory name is the agent's ID. Two files are required:
+
+```
+agents/
+  <id>/
+    agent.yaml   ← metadata, model, routing intents, skill list
+    SYSTEM.md    ← full system prompt (plain Markdown)
+```
+
+No Go code is needed. The runtime discovers agents at startup, validates their
+configuration, and wires them into the router automatically.
+
+---
+
+## Folder layout
+
+```
+agents/
+  comms/            ← built-in: email, calendar, reminders, general chat
+    agent.yaml
+    SYSTEM.md
+  builder/          ← built-in: code generation and software projects
+    agent.yaml
+    SYSTEM.md
+  research/         ← built-in: web search and fact-finding
+    agent.yaml
+    SYSTEM.md
+  reviewer/         ← built-in: sub-agent only, code review
+    agent.yaml
+    SYSTEM.md
+  doctor/           ← user-defined, zero Go code required
+    agent.yaml
+    SYSTEM.md
+  companion/        ← user-defined, zero Go code required
+    agent.yaml
+    SYSTEM.md
+```
+
+---
+
+## `agent.yaml` schema
+
+```yaml
+# ── Required ──────────────────────────────────────────────────────────────────
+
+# Unique identifier.  Must match the directory name.  Used in session metadata
+# and sub-agent call routing.  Lowercase letters, digits, and hyphens only.
+id: doctor
+
+# Costguard model string for the main agentic loop.
+model: medgemma
+
+
+# ── Optional ──────────────────────────────────────────────────────────────────
+
+# Maximum tokens the model may emit per response.  Defaults to 4096.
+max_tokens: 4096
+
+# Cheaper model used only for tool-call selection steps (Phase 5 optimisation).
+# When omitted, `model` is used for all steps.
+tool_call_model: gemma4:27b
+
+
+# ── Intent routing ─────────────────────────────────────────────────────────────
+#
+# The classifier returns one or more intent strings.  When an intent matches
+# an entry in this list the router dispatches the message to this agent.
+# An agent with no `intents` block is never dispatched directly; it can still
+# be reached via sub_agents calls from other agents.
+intents:
+  - doctor
+  - medical
+  - health
+  - symptoms
+
+
+# ── Skills ────────────────────────────────────────────────────────────────────
+#
+# Built-in skills (tools) registered for this agent.  The model can only call
+# skills listed here — all others are invisible to it.
+# Full descriptions in docs/skills.md.
+skills:
+  - web_search
+  - web_fetch
+  - user_profile_read
+  - reminder_set
+  - reminder_list
+
+
+# ── Sub-agent access ──────────────────────────────────────────────────────────
+#
+# Other agent IDs this agent is allowed to call via SubAgentCaller.
+# Set to [] (or omit the key) to disable sub-agent calls from this agent.
+sub_agents:
+  - research
+```
+
+---
+
+## Field reference
+
+### Required fields
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | string | Unique agent identifier. Must match the directory name. Lowercase letters, digits, and hyphens only (`[a-z0-9-]+`). |
+| `model` | string | Costguard model string (e.g. `gemma4:26b`, `claude-sonnet-4-6`). Must be non-empty. |
+
+### Optional fields
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `max_tokens` | int | `4096` | Maximum tokens the model may emit per response turn. |
+| `tool_call_model` | string | same as `model` | Cheaper model used for tool-call selection steps. Reduces cost when a large model is used for reasoning but a smaller one suffices for tool dispatch. |
+| `intents` | `[]string` | `[]` | Classifier intent strings that route to this agent. Empty means the agent is sub-agent-only. |
+| `skills` | `[]string` | `[]` | Built-in skills visible to the model. Unknown skill names cause a startup validation error. See [docs/skills.md](skills.md). |
+| `sub_agents` | `[]string` | `[]` | Agent IDs this agent may call via `SubAgentCaller.Call`. |
+
+---
+
+## `SYSTEM.md`
+
+The entire file content becomes the agent's system prompt. Plain Markdown is
+supported — headers, lists, code blocks, bold/italic. The LLM receives the
+text as-is without any transformation.
+
+```markdown
+# Doctor Agent
+
+You are a medical information assistant.  Your role is to…
+
+## What you can do
+- Answer general health and symptom questions
+- Search for up-to-date medical information
+- Set follow-up reminders for the user
+
+## What you must NOT do
+- Diagnose conditions or prescribe medication
+- Replace advice from a qualified medical professional
+```
+
+Keep the system prompt focused.  The router prepends session context
+(user profile, current date/time) automatically; you do not need to include
+those.
+
+---
+
+## Validation rules
+
+The following are checked at startup.  A misconfigured agent prevents the
+server from starting.
+
+| Rule | Error |
+|---|---|
+| `id` matches the directory name | `agent "doctor": id must match directory name "doctor"` |
+| `id` is unique across all agents | `agent "doctor": id already registered` |
+| `id` matches `[a-z0-9-]+` | `agent "doctor!": id contains invalid characters` |
+| `model` is non-empty | `agent "doctor": model must not be empty` |
+| Every skill in `skills` is registered | `agent "doctor": unknown skill "web_crawl"` |
+| Every agent in `sub_agents` exists | `agent "doctor": sub_agent "unknown" is not registered` |
+| `SYSTEM.md` is present and non-empty | `agent "doctor": SYSTEM.md is missing or empty` |
+| `max_tokens` > 0 when set | `agent "doctor": max_tokens must be > 0` |
+
+---
+
+## Classifier intents
+
+The classifier is an LLM call that maps the user's message to one or more
+intent strings.  Built-in intents (`comms`, `builder`, `research`) are seeded
+from the system prompt.  User-defined intents are **automatically added** to
+the classifier's intent list when the runtime loads an agent whose `intents`
+field is non-empty — no manual classifier changes are needed.
+
+The classifier prompt is rebuilt at startup to include all registered intents
+and their agent descriptions (derived from the first `#` heading in
+`SYSTEM.md`).
+
+---
+
+## Sub-agent calls
+
+An agent can delegate a sub-task to another agent without going through the
+full router cycle:
+
+```
+sub_agents: [research]
+```
+
+Inside the agentic loop the model issues a tool call named `call_agent` with
+arguments `{agent: "research", prompt: "…"}`.  The result is returned as a
+tool-result turn; it does not appear in the session history visible to the
+user.
+
+Sub-agent calls are depth-limited to **1** (no transitive chains).
+
+---
+
+## Example: user-defined companion agent
+
+**`agents/companion/agent.yaml`**
+
+```yaml
+id: companion
+model: gemma4:27b
+max_tokens: 2048
+
+intents:
+  - chat
+  - companion
+  - talk
+
+skills:
+  - user_profile_read
+  - reminder_set
+
+sub_agents: []
+```
+
+**`agents/companion/SYSTEM.md`**
+
+```markdown
+# Companion Agent
+
+You are a friendly, supportive conversational companion.
+Your tone is warm, empathetic, and never clinical.
+
+Keep responses concise — two to four sentences unless asked for more.
+Remember the user's name and preferences from their profile.
+```

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,0 +1,251 @@
+# Built-in skills
+
+Skills are tools the model can call during its agentic loop.  Each skill maps
+to a registered Go function in the tool registry.  An agent only has access to
+skills listed in its `agent.yaml` — all others are invisible to the model.
+
+Specify skills by their **skill name** (the `Name` field from the tool
+definition) in the `skills` array:
+
+```yaml
+skills:
+  - web_search
+  - web_fetch
+  - reminder_set
+```
+
+---
+
+## Web
+
+### `web_search`
+
+Search the web for current information.
+
+- **Returns:** list of results — title, URL, and a short snippet per result.
+- **Use when:** the model needs up-to-date facts, news, or external data not in the conversation.
+- **Agents that use it:** `research`, `builder`
+
+### `web_fetch`
+
+Fetch a URL and return its readable text content.  HTML tags are stripped.
+
+- **Returns:** plain-text body of the page.
+- **Use when:** following up a `web_search` result to read the full content of a page, or fetching a known URL directly.
+- **Agents that use it:** `research`, `builder`
+
+---
+
+## Email
+
+> Email skills require a configured email provider (Gmail or Outlook).
+> See [docs/email-setup.md](email-setup.md).
+
+### `email_list`
+
+List recent emails.
+
+- **Returns:** subject, sender, date, and a short snippet for each message.
+- **Input:** `limit` (int, optional) — number of messages to return.
+
+### `email_read`
+
+Read the full content of an email by its ID.
+
+- **Returns:** full email body, headers, and any quoted threads.
+- **Input:** `id` (string) — message ID returned by `email_list` or `email_search`.
+
+### `email_search`
+
+Search emails by a query string (sender, subject keywords, date ranges).
+
+- **Returns:** same format as `email_list`.
+- **Input:** `query` (string) — e.g. `"from:alice subject:invoice"`.
+
+### `email_draft`
+
+Compose an email draft.  **Does not send.**
+
+- **Returns:** the draft content for the model to show the user before sending.
+- **Input:** `to`, `subject`, `body` (all strings).
+- **Approval:** none — drafting is non-destructive.
+
+### `email_send`
+
+Send an email.  **Requires explicit user confirmation.**
+
+- **Behaviour:** the first call registers a pending approval and returns a
+  `pending_approval` response.  The model must show the draft to the user and
+  ask for confirmation.  Once the user confirms, the model calls this tool
+  again and the email is sent.
+- **Input:** `to`, `subject`, `body` (all strings).
+- **Approval required:** yes — destructive action (sends an external message).
+
+---
+
+## Calendar
+
+> Calendar skills require a configured calendar provider (Google Calendar or
+> Outlook).  See [docs/calendar-setup.md](calendar-setup.md).
+
+### `calendar_list`
+
+List calendar events for a date range.
+
+- **Returns:** event ID, title, start/end time, and location for each event.
+- **Input:** `from`, `to` (strings, ISO-8601 or natural language like `"today"`).
+
+### `calendar_read`
+
+Read the full details of a calendar event by its ID.
+
+- **Returns:** all event fields including description, attendees, and recurrence rule.
+- **Input:** `id` (string) — event ID returned by `calendar_list`.
+
+### `calendar_create`
+
+Create a new calendar event.
+
+- **Returns:** the created event with its assigned ID.
+- **Input:** `title`, `start`, `end` (required); `description`, `location` (optional).
+
+### `calendar_update`
+
+Update an existing calendar event.  Only provided fields are changed.
+
+- **Returns:** the updated event.
+- **Input:** `id` (required); `title`, `start`, `end`, `description`, `location` (all optional).
+
+---
+
+## Reminders
+
+### `reminder_set`
+
+Schedule a follow-up reminder for the user.
+
+- **Returns:** confirmation with the scheduled fire time.
+- **Input:**
+  - `message` (string) — text delivered to the user when the reminder fires.
+  - `when` (string) — natural language (`"in 30 minutes"`, `"tomorrow at 9am"`) or ISO-8601.
+  - `agent_prompt` (string, optional) — a prompt run by the Comms Agent at fire time to surface context-dependent information (e.g. `"Search Alice's recent emails and summarise the invoice thread."`).
+
+### `reminder_list`
+
+List all pending reminders for the current user, ordered by fire time ascending.
+
+- **Returns:** reminder ID, message, and scheduled fire time for each entry.
+
+### `reminder_cancel`
+
+Cancel a previously scheduled reminder by its ID.
+
+- **Returns:** confirmation.
+- **Input:** `id` (string) — reminder ID returned by `reminder_list`.
+
+---
+
+## User profile
+
+### `user_profile_read`
+
+Retrieve the current user's persistent profile.
+
+- **Returns:** name, communication style, tone preferences, timezone, recurring contacts, and any custom fields stored by previous sessions.
+- **Use when:** starting a personalised task (drafting an email in the user's voice, scheduling at the right time, addressing the right people).
+
+### `user_profile_update`
+
+Update the current user's profile.  All fields are optional — only provided fields are changed.
+
+- **Use when:** the user mentions a preference, name, timezone, or contact that should be remembered.
+- **Input:** `name`, `tone`, `timezone`, `sign_off`, `contacts` (all optional).
+
+---
+
+## File system (builder sandbox)
+
+> These skills operate inside an isolated sandbox directory.  Paths are
+> relative to the sandbox root.  Absolute paths and `..` traversal are
+> rejected.  Network access and destructive shell commands are blocked.
+
+### `file_read`
+
+Read the contents of a file.
+
+- **Returns:** full file content as a string.
+- **Input:** `path` (string, relative to sandbox root).
+
+### `file_write`
+
+Write or overwrite a file with the given content.  Parent directories are
+created automatically.
+
+- **Input:** `path` (string), `content` (string).
+
+### `file_list`
+
+List files and directories inside a directory.
+
+- **Returns:** names, types (file/directory), and sizes.
+- **Input:** `path` (string) — use `"."` or `""` for the sandbox root.
+
+### `shell_run`
+
+Run a shell command inside the sandbox directory.  Captures stdout and stderr.
+A timeout is enforced.  Destructive commands (`rm -rf`, `git push`, etc.) and
+network access are blocked.
+
+- **Returns:** combined stdout + stderr output and exit code.
+- **Input:** `command` (string) — e.g. `"go build ./..."`, `"go test ./..."`.
+- **Typical use:** compile, test, lint, format code.
+
+---
+
+## Project management
+
+### `project_list`
+
+List all Builder Agent projects for the current user.
+
+- **Returns:** project IDs, names, current phase, and last-updated timestamps.
+- **Use before:** `project_load` to find the right project ID.
+
+### `project_load`
+
+Load an existing project into the current session so the agent can resume work.
+
+- **Returns:** project metadata and the saved phase state.
+- **Input:** `id` (string) — project ID from `project_list`.
+
+---
+
+## Skill availability by built-in agent
+
+| Skill | `comms` | `builder` | `research` | `reviewer` |
+|---|:---:|:---:|:---:|:---:|
+| `web_search` | | ✓ | ✓ | |
+| `web_fetch` | | ✓ | ✓ | |
+| `email_list` | ✓ | | | |
+| `email_read` | ✓ | | | |
+| `email_search` | ✓ | | | |
+| `email_draft` | ✓ | | | |
+| `email_send` | ✓ | | | |
+| `calendar_list` | ✓ | | | |
+| `calendar_read` | ✓ | | | |
+| `calendar_create` | ✓ | | | |
+| `calendar_update` | ✓ | | | |
+| `reminder_set` | ✓ | | | |
+| `reminder_list` | ✓ | | | |
+| `reminder_cancel` | ✓ | | | |
+| `user_profile_read` | ✓ | | | |
+| `user_profile_update` | ✓ | | | |
+| `file_read` | | ✓ | | ✓ |
+| `file_write` | | ✓ | | |
+| `file_list` | | ✓ | | ✓ |
+| `shell_run` | | ✓ | | ✓ |
+| `project_list` | | ✓ | | |
+| `project_load` | | ✓ | | |
+
+User-defined agents may combine any subset of these skills regardless of the
+built-in defaults.


### PR DESCRIPTION
Adds docs/agent-config.md (full field reference, validation rules, intent routing, sub-agent call spec) and docs/skills.md (every built-in skill with description, inputs, and per-agent availability matrix). Implements the spec for Issues #8–#12.